### PR TITLE
Make gzip-filter work with nanoc 4.x

### DIFF
--- a/lib/nanoc-gzip-filter.rb
+++ b/lib/nanoc-gzip-filter.rb
@@ -1,11 +1,1 @@
-require 'nanoc'
-require 'zlib'
-
-module Nanoc
-  module Filters
-    autoload 'Gzip', 'nanoc/filters/gzip'
-
-    Nanoc::Filter.register '::Nanoc::Filters::Gzip', :gzip
-  end
-end
-
+require 'nanoc/filters/gzip'

--- a/lib/nanoc/filters/gzip.rb
+++ b/lib/nanoc/filters/gzip.rb
@@ -1,24 +1,23 @@
 require 'nanoc'
+require 'zlib'
 
-module Nanoc
-  module Filters
-    class Gzip < Nanoc::Filter
-      VERSION = '0.0.1'
+module Nanoc::Filters
+  class Gzip < Nanoc::Filter
+    VERSION = '0.0.1'
 
-      type :text => :binary
+    identifier :gzip
+    type :text
 
-      def run(content, params = {})
-        Zlib::GzipWriter.open(output_filename, Zlib::BEST_COMPRESSION) do |gz|
-          gz.orig_name = File.basename(item[:filename])
-          gz.mtime = mtime.to_i
-          gz.write content
-        end
+    def run(content, params = {})
+      Zlib::GzipWriter.open(output_filename, Zlib::BEST_COMPRESSION) do |gz|
+        gz.orig_name = File.basename(item[:filename])
+        gz.mtime = mtime.to_i
+        gz.write content
       end
+    end
 
-      def mtime
-        File.mtime(item[:filename])
-      end
-
+    def mtime
+      File.mtime(item[:filename])
     end
   end
 end

--- a/lib/nanoc/filters/gzip.rb
+++ b/lib/nanoc/filters/gzip.rb
@@ -3,7 +3,7 @@ require 'zlib'
 
 module Nanoc::Filters
   class Gzip < Nanoc::Filter
-    VERSION = '0.0.1'
+    VERSION = '0.0.2'
 
     identifier :gzip
     type :text

--- a/nanoc-gzip-filter.gemspec
+++ b/nanoc-gzip-filter.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Nanoc::Filters::Gzip::VERSION
 
-  gem.add_dependency 'nanoc',     '>= 3.4.0'
+  gem.add_dependency 'nanoc',     '>= 4.4.0'
 
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Hi @yannlugrin,

thanks for providing `nanoc-gzip-filter`.
I use it to compress my xml-sitemaps.

I upgraded to nanoc `4.6` and the `:gzip`-filter stopped working.
It seems that the function `Nanoc::Filter:Class.register` has been removed.
I got the following error

```
Gem Load Error is: undefined method `register' for Nanoc::Filter:Class
```

That's why I updated your Gem to get it work with the current version of nanoc (https://nanoc.ws/doc/filters/).

Please have a look at it.
If there are any questions please contact me.

Kinds 
Greg